### PR TITLE
Initialize Word Wizards vertical slice scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+.DS_Store
+dist
+.idea
+.vscode
+package-lock.json
+npm-debug.log*

--- a/README.md
+++ b/README.md
@@ -1,8 +1,38 @@
-# hello-world
-This is my first repository
+# Word Wizards (Vertical Slice)
 
+A hybrid-ready mobile game prototype where spelling words casts spells against theatrical bosses. The repo is structured for a React + Vite web build that can be wrapped with Capacitor for iOS/Android.
 
-Hi Humans,
+## Highlights
+- **Core loop demo:** Draft words from a letter pool, discover new spells, and recast them with mana.
+- **Boss variety:** Three themed bosses (Leximancer, Queen Anagramma, Silent Editor) with distinct quirks.
+- **Mobile-friendly UI:** Responsive layout, tactile tile styling, and lightweight CSS with no external UI kit.
+- **Capacitor ready:** `capacitor.config.ts` preconfigured for wrapping the Vite build.
 
-I'm Blue and I like Node.js and Angular (it's what I'm made of).
-I've had tacos on the moon and I find them far superior to Earth tacos.
+## Getting started
+1. Install dependencies (from a networked environment):
+   ```bash
+   npm install
+   ```
+2. Run the dev server:
+   ```bash
+   npm run dev
+   ```
+3. Build for web/Capacitor:
+   ```bash
+   npm run build
+   ```
+4. Initialize native platforms (from a machine with Android/iOS toolchains):
+   ```bash
+   npx cap add ios
+   npx cap add android
+   npx cap sync
+   ```
+
+## Next steps
+- Add validation against a dictionary service to score real words.
+- Implement enemy attack turns and player shields/blocks.
+- Wire analytics + persistence for learned spells.
+- Hook up RevenueCat/ads as desired.
+
+## License
+MIT

--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ A hybrid-ready mobile game prototype where spelling words casts spells against t
 
 ## Highlights
 - **Combat loop:** Draft words from a letter pool, discover new spells, and recast them with mana and a growing combo multiplier.
-- **Boss pressure:** Three themed bosses (Leximancer, Queen Anagramma, Silent Editor) with distinct quirks, tells, and a counterattack turn.
-- **Player agency:** Shields, mana regen, rerollable letter pools, and spell traits (palindromes, rare letters, weakness hits) that change damage and rewards.
+- **Procedural bosses:** Each encounter procedurally remixes boss archetypes (title, skills, sigil, palette, health) so every run feels unique while keeping themed mechanics.
+- **Boss pressure:** Unique boss sigils/gradients, bespoke skill chips, weakness hints, and adaptive tells that rotate through their active skill list.
+- **Player agency:** Shields, mana regen, rerollable letter pools, and spell traits (palindromes, rare letters, weakness hits) that change damage and rewards; letter pools bias toward the boss element for tactical drafting.
 - **Mobile-friendly UI:** Responsive layout, tactile tile styling, and lightweight CSS with no external UI kit.
 - **Capacitor ready:** `capacitor.config.ts` preconfigured for wrapping the Vite build.
 
@@ -31,6 +32,7 @@ A hybrid-ready mobile game prototype where spelling words casts spells against t
 
 ## Next steps
 - Wire a real dictionary validator to gate damage and award bigger bonuses for rare words.
+- Add procedural spell mods (elemental twists, mana/synergy perks) so discovered spells evolve run to run.
 - Build the Forge/upgrade screen between bosses (augment spells, add mana shards, reroll perks).
 - Persist runs + analytics events and add hooks for RevenueCat/IAPs.
 - Layer in VFX (hit sparks, screen shake, haptics) and a soundtrack loop.

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 A hybrid-ready mobile game prototype where spelling words casts spells against theatrical bosses. The repo is structured for a React + Vite web build that can be wrapped with Capacitor for iOS/Android.
 
 ## Highlights
-- **Core loop demo:** Draft words from a letter pool, discover new spells, and recast them with mana.
-- **Boss variety:** Three themed bosses (Leximancer, Queen Anagramma, Silent Editor) with distinct quirks.
+- **Combat loop:** Draft words from a letter pool, discover new spells, and recast them with mana and a growing combo multiplier.
+- **Boss pressure:** Three themed bosses (Leximancer, Queen Anagramma, Silent Editor) with distinct quirks, tells, and a counterattack turn.
+- **Player agency:** Shields, mana regen, rerollable letter pools, and spell traits (palindromes, rare letters, weakness hits) that change damage and rewards.
 - **Mobile-friendly UI:** Responsive layout, tactile tile styling, and lightweight CSS with no external UI kit.
 - **Capacitor ready:** `capacitor.config.ts` preconfigured for wrapping the Vite build.
 
@@ -29,10 +30,10 @@ A hybrid-ready mobile game prototype where spelling words casts spells against t
    ```
 
 ## Next steps
-- Add validation against a dictionary service to score real words.
-- Implement enemy attack turns and player shields/blocks.
-- Wire analytics + persistence for learned spells.
-- Hook up RevenueCat/ads as desired.
+- Wire a real dictionary validator to gate damage and award bigger bonuses for rare words.
+- Build the Forge/upgrade screen between bosses (augment spells, add mana shards, reroll perks).
+- Persist runs + analytics events and add hooks for RevenueCat/IAPs.
+- Layer in VFX (hit sparks, screen shake, haptics) and a soundtrack loop.
 
 ## License
 MIT

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -1,0 +1,13 @@
+import { CapacitorConfig } from '@capacitor/cli';
+
+const config: CapacitorConfig = {
+  appId: 'com.wordwizards.game',
+  appName: 'Word Wizards',
+  webDir: 'dist',
+  bundledWebRuntime: false,
+  server: {
+    androidScheme: 'https'
+  }
+};
+
+export default config;

--- a/index.html
+++ b/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Word Wizards</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "word-wizards",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@capacitor/core": "^6.0.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@capacitor/cli": "^6.0.0",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^5.0.4",
+    "typescript": "^5.6.3",
+    "vite": "^5.4.11"
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,9 +29,11 @@ const initialPlayer: PlayerState = {
   combo: 0
 };
 
+const initialBoss: Boss = pickBoss();
+
 function App() {
-  const [boss, setBoss] = useState<Boss>(pickBoss());
-  const [letters, setLetters] = useState(generateLetters(9));
+  const [boss, setBoss] = useState<Boss>(initialBoss);
+  const [letters, setLetters] = useState(generateLetters(9, initialBoss.element, initialBoss.letterBias));
   const [spellbook, setSpellbook] = useState<Spell[]>(initialSpellbook);
   const [log, setLog] = useState<string[]>(['Battle initiated.']);
   const [mana, setMana] = useState(3);
@@ -47,11 +49,10 @@ function App() {
   const encounterActive = boss.health > 0 && player.health > 0;
 
   const bossTell = useMemo(() => {
-    const cycle = turn % 3;
-    if (cycle === 0) return 'Charged strike incoming—shields help.';
-    if (cycle === 1) return 'Studying you—damage slightly reduced.';
-    return 'Quick jab; push your combo!';
-  }, [turn]);
+    if (!boss.skills.length) return '';
+    const cycle = (turn - 1) % boss.skills.length;
+    return boss.skills[cycle]?.tell;
+  }, [boss.skills, turn]);
 
   const resolveBossTurn = (projectedTurn: number, projectedBossHealth: number) => {
     setTurn(projectedTurn);
@@ -103,7 +104,7 @@ function App() {
       ...prev
     ]);
     setBoss((prev) => ({ ...prev, health: newBossHealth }));
-    setLetters(generateLetters(9));
+    setLetters(generateLetters(9, boss.element, boss.letterBias));
     setMana((prev) => Math.min(8, prev + resolution.manaBonus));
     setPlayer((prev) => ({
       ...prev,
@@ -152,8 +153,9 @@ function App() {
   };
 
   const handleNewRun = () => {
-    setBoss(pickBoss());
-    setLetters(generateLetters(9));
+    const freshBoss = pickBoss();
+    setBoss(freshBoss);
+    setLetters(generateLetters(9, freshBoss.element, freshBoss.letterBias));
     setSpellbook(initialSpellbook);
     setLog(['New encounter.']);
     setMana(3);
@@ -163,7 +165,7 @@ function App() {
 
   const handleReroll = () => {
     if (!encounterActive) return;
-    setLetters(generateLetters(9));
+    setLetters(generateLetters(9, boss.element, boss.letterBias));
     setLog((prev) => ['Letter pool rerolled.', ...prev]);
   };
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,8 +3,9 @@ import BossCard from './components/BossCard';
 import LetterPool from './components/LetterPool';
 import Spellbook from './components/Spellbook';
 import TurnLog from './components/TurnLog';
-import type { Boss, Spell } from './types';
-import { generateLetters, pickBoss } from './logic/core';
+import RunStats from './components/RunStats';
+import type { Boss, PlayerState, Spell } from './types';
+import { generateLetters, pickBoss, resolveWord } from './logic/core';
 
 const initialSpellbook: Spell[] = [
   {
@@ -21,6 +22,13 @@ const initialSpellbook: Spell[] = [
   }
 ];
 
+const initialPlayer: PlayerState = {
+  health: 120,
+  maxHealth: 120,
+  shield: 10,
+  combo: 0
+};
+
 function App() {
   const [boss, setBoss] = useState<Boss>(pickBoss());
   const [letters, setLetters] = useState(generateLetters(9));
@@ -28,6 +36,7 @@ function App() {
   const [log, setLog] = useState<string[]>(['Battle initiated.']);
   const [mana, setMana] = useState(3);
   const [turn, setTurn] = useState(1);
+  const [player, setPlayer] = useState<PlayerState>(initialPlayer);
 
   const manaHint = useMemo(() => {
     if (mana <= 1) return 'Low mana—improvise with letters!';
@@ -35,42 +44,111 @@ function App() {
     return 'Balance improvisation with planned casts.';
   }, [mana]);
 
+  const encounterActive = boss.health > 0 && player.health > 0;
+
+  const bossTell = useMemo(() => {
+    const cycle = turn % 3;
+    if (cycle === 0) return 'Charged strike incoming—shields help.';
+    if (cycle === 1) return 'Studying you—damage slightly reduced.';
+    return 'Quick jab; push your combo!';
+  }, [turn]);
+
+  const resolveBossTurn = (projectedTurn: number, projectedBossHealth: number) => {
+    setTurn(projectedTurn);
+    setMana((prev) => Math.min(8, prev + 1));
+
+    if (projectedBossHealth <= 0) {
+      setLog((prev) => ['Boss defeated! Forge an upgrade and push deeper.', ...prev]);
+      return;
+    }
+
+    setPlayer((prev) => {
+      const attack = Math.round(12 + projectedTurn * 1.3 + Math.max(0, prev.combo - 2));
+      const blocked = Math.min(prev.shield, attack);
+      const remaining = Math.max(0, attack - blocked);
+      const nextShield = Math.max(0, prev.shield - attack);
+      const nextHealth = Math.max(0, prev.health - remaining);
+      const resetCombo = remaining > 0 ? 0 : prev.combo;
+
+      setLog((prevLog) => [
+        `${boss.name} strikes for ${attack}. Shield blocked ${blocked}. (${remaining} damage)`,
+        ...prevLog
+      ]);
+
+      return {
+        ...prev,
+        shield: nextShield,
+        health: nextHealth,
+        combo: resetCombo
+      };
+    });
+  };
+
   const handleCastWord = (word: string) => {
+    if (!encounterActive) {
+      setLog((prev) => ['Encounter over—start a new boss.', ...prev]);
+      return;
+    }
+
     const upper = word.toUpperCase();
     const exists = spellbook.find((spell) => spell.name === upper);
-    const manaCost = Math.max(1, Math.floor(word.length / 2));
+    const resolution = resolveWord(upper, boss.weakness, player.combo);
+
+    const newBossHealth = Math.max(0, boss.health - resolution.damage);
 
     setLog((prev) => [
-      `${upper} erupts for ${word.length * 5} damage.`,
+      `${upper} erupts for ${resolution.damage} ${resolution.element} damage. Traits: ${
+        resolution.traits.join(', ') || 'improvised'
+      }.`,
       ...prev
     ]);
-    setBoss((prev) => ({ ...prev, health: Math.max(0, prev.health - word.length * 5) }));
+    setBoss((prev) => ({ ...prev, health: newBossHealth }));
     setLetters(generateLetters(9));
-    setTurn((prev) => prev + 1);
+    setMana((prev) => Math.min(8, prev + resolution.manaBonus));
+    setPlayer((prev) => ({
+      ...prev,
+      combo: prev.combo + 1,
+      shield: Math.min(prev.shield + resolution.shieldBonus, 20)
+    }));
 
     if (!exists) {
       const newSpell: Spell = {
         name: upper,
         description: 'Freshly discovered incantation. Tune it in the Forge.',
-        manaCost,
-        element: 'arcane'
+        manaCost: Math.max(1, Math.floor(word.length / 2)),
+        element: resolution.element
       };
       setSpellbook((prev) => [newSpell, ...prev]);
       setLog((prev) => [`New spell discovered: ${upper}.`, ...prev]);
-    } else {
-      setMana((prev) => Math.max(0, prev - manaCost));
     }
+
+    resolveBossTurn(turn + 1, newBossHealth);
   };
 
   const handleRecast = (spell: Spell) => {
+    if (!encounterActive) {
+      setLog((prev) => ['Encounter over—start a new boss.', ...prev]);
+      return;
+    }
+
     if (mana < spell.manaCost) {
       setLog((prev) => ['Not enough mana to recast.', ...prev]);
       return;
     }
-    setMana((prev) => prev - spell.manaCost);
-    setBoss((prev) => ({ ...prev, health: Math.max(0, prev.health - spell.manaCost * 12) }));
-    setLog((prev) => [`${spell.name} reverberates for ${spell.manaCost * 12} damage.`, ...prev]);
-    setTurn((prev) => prev + 1);
+
+    const weaknessBonus = spell.element === boss.weakness ? 1.15 : 1;
+    const damage = Math.round((spell.manaCost * 14 + player.combo * 4) * weaknessBonus);
+    const newBossHealth = Math.max(0, boss.health - damage);
+
+    setMana((prev) => Math.max(0, prev - spell.manaCost));
+    setBoss((prev) => ({ ...prev, health: newBossHealth }));
+    setLog((prev) => [
+      `${spell.name} reverberates for ${damage} damage (${spell.manaCost} MP).`,
+      ...prev
+    ]);
+    setPlayer((prev) => ({ ...prev, combo: prev.combo + 1 }));
+
+    resolveBossTurn(turn + 1, newBossHealth);
   };
 
   const handleNewRun = () => {
@@ -80,6 +158,13 @@ function App() {
     setLog(['New encounter.']);
     setMana(3);
     setTurn(1);
+    setPlayer(initialPlayer);
+  };
+
+  const handleReroll = () => {
+    if (!encounterActive) return;
+    setLetters(generateLetters(9));
+    setLog((prev) => ['Letter pool rerolled.', ...prev]);
   };
 
   return (
@@ -89,9 +174,9 @@ function App() {
           <p className="eyebrow">Word Wizards · Vertical Slice</p>
           <h1>Spell words. Break bosses.</h1>
           <p className="lede">
-            Draft words from the letter pool to improvise spells. Recast discovered spells with mana to
-            exploit boss weaknesses. This slice focuses on one quick encounter loop you can drop into
-            Capacitor builds.
+            Draft words from the letter pool to improvise spells. Recast discovered spells with mana and
+            sustain your combo to exploit boss weaknesses. This slice focuses on an upgraded encounter
+            loop you can drop into Capacitor builds.
           </p>
           <div className="hero-actions">
             <button className="primary" onClick={handleNewRun}>New Boss</button>
@@ -101,11 +186,11 @@ function App() {
         <div className="stat-card">
           <p className="label">Mana</p>
           <div className="meter">
-            <div className="fill" style={{ width: `${Math.min(100, (mana / 6) * 100)}%` }} />
+            <div className="fill" style={{ width: `${Math.min(100, (mana / 8) * 100)}%` }} />
           </div>
           <p className="hint">{manaHint}</p>
-          <p className="label">Turn</p>
-          <p className="value">{turn}</p>
+          <p className="label">Shield</p>
+          <p className="value">{player.shield}</p>
         </div>
       </header>
 
@@ -115,16 +200,24 @@ function App() {
             <h2>Boss Arena</h2>
             <p className="label">Slice-ready encounter</p>
           </div>
-          <BossCard boss={boss} />
-          <LetterPool letters={letters} onCast={handleCastWord} />
+          <BossCard boss={boss} tell={bossTell} />
+          <LetterPool letters={letters} onCast={handleCastWord} onReroll={handleReroll} disabled={!encounterActive} />
         </section>
+
+        <RunStats
+          player={player}
+          mana={mana}
+          turn={turn}
+          discoveredSpells={spellbook}
+          bossName={boss.name}
+        />
 
         <section className="panel">
           <div className="panel-head">
             <h2>Spellbook</h2>
             <p className="label">Discovered incantations</p>
           </div>
-          <Spellbook spells={spellbook} onRecast={handleRecast} />
+          <Spellbook spells={spellbook} onRecast={handleRecast} disabled={!encounterActive} manaAvailable={mana} />
         </section>
 
         <section className="panel">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,142 @@
+import { useMemo, useState } from 'react';
+import BossCard from './components/BossCard';
+import LetterPool from './components/LetterPool';
+import Spellbook from './components/Spellbook';
+import TurnLog from './components/TurnLog';
+import type { Boss, Spell } from './types';
+import { generateLetters, pickBoss } from './logic/core';
+
+const initialSpellbook: Spell[] = [
+  {
+    name: 'EMBER',
+    description: 'A quick flicker of flame that scorches lightly.',
+    manaCost: 1,
+    element: 'fire'
+  },
+  {
+    name: 'AURA',
+    description: 'A steady wave of force that steadies your footing.',
+    manaCost: 2,
+    element: 'arcane'
+  }
+];
+
+function App() {
+  const [boss, setBoss] = useState<Boss>(pickBoss());
+  const [letters, setLetters] = useState(generateLetters(9));
+  const [spellbook, setSpellbook] = useState<Spell[]>(initialSpellbook);
+  const [log, setLog] = useState<string[]>(['Battle initiated.']);
+  const [mana, setMana] = useState(3);
+  const [turn, setTurn] = useState(1);
+
+  const manaHint = useMemo(() => {
+    if (mana <= 1) return 'Low mana—improvise with letters!';
+    if (mana >= 4) return 'High mana—chain learned spells.';
+    return 'Balance improvisation with planned casts.';
+  }, [mana]);
+
+  const handleCastWord = (word: string) => {
+    const upper = word.toUpperCase();
+    const exists = spellbook.find((spell) => spell.name === upper);
+    const manaCost = Math.max(1, Math.floor(word.length / 2));
+
+    setLog((prev) => [
+      `${upper} erupts for ${word.length * 5} damage.`,
+      ...prev
+    ]);
+    setBoss((prev) => ({ ...prev, health: Math.max(0, prev.health - word.length * 5) }));
+    setLetters(generateLetters(9));
+    setTurn((prev) => prev + 1);
+
+    if (!exists) {
+      const newSpell: Spell = {
+        name: upper,
+        description: 'Freshly discovered incantation. Tune it in the Forge.',
+        manaCost,
+        element: 'arcane'
+      };
+      setSpellbook((prev) => [newSpell, ...prev]);
+      setLog((prev) => [`New spell discovered: ${upper}.`, ...prev]);
+    } else {
+      setMana((prev) => Math.max(0, prev - manaCost));
+    }
+  };
+
+  const handleRecast = (spell: Spell) => {
+    if (mana < spell.manaCost) {
+      setLog((prev) => ['Not enough mana to recast.', ...prev]);
+      return;
+    }
+    setMana((prev) => prev - spell.manaCost);
+    setBoss((prev) => ({ ...prev, health: Math.max(0, prev.health - spell.manaCost * 12) }));
+    setLog((prev) => [`${spell.name} reverberates for ${spell.manaCost * 12} damage.`, ...prev]);
+    setTurn((prev) => prev + 1);
+  };
+
+  const handleNewRun = () => {
+    setBoss(pickBoss());
+    setLetters(generateLetters(9));
+    setSpellbook(initialSpellbook);
+    setLog(['New encounter.']);
+    setMana(3);
+    setTurn(1);
+  };
+
+  return (
+    <div className="page">
+      <header className="hero">
+        <div>
+          <p className="eyebrow">Word Wizards · Vertical Slice</p>
+          <h1>Spell words. Break bosses.</h1>
+          <p className="lede">
+            Draft words from the letter pool to improvise spells. Recast discovered spells with mana to
+            exploit boss weaknesses. This slice focuses on one quick encounter loop you can drop into
+            Capacitor builds.
+          </p>
+          <div className="hero-actions">
+            <button className="primary" onClick={handleNewRun}>New Boss</button>
+            <button className="ghost">Roadmap · Slice 2</button>
+          </div>
+        </div>
+        <div className="stat-card">
+          <p className="label">Mana</p>
+          <div className="meter">
+            <div className="fill" style={{ width: `${Math.min(100, (mana / 6) * 100)}%` }} />
+          </div>
+          <p className="hint">{manaHint}</p>
+          <p className="label">Turn</p>
+          <p className="value">{turn}</p>
+        </div>
+      </header>
+
+      <main className="grid">
+        <section className="panel">
+          <div className="panel-head">
+            <h2>Boss Arena</h2>
+            <p className="label">Slice-ready encounter</p>
+          </div>
+          <BossCard boss={boss} />
+          <LetterPool letters={letters} onCast={handleCastWord} />
+        </section>
+
+        <section className="panel">
+          <div className="panel-head">
+            <h2>Spellbook</h2>
+            <p className="label">Discovered incantations</p>
+          </div>
+          <Spellbook spells={spellbook} onRecast={handleRecast} />
+        </section>
+
+        <section className="panel">
+          <div className="panel-head">
+            <h2>Turn Log</h2>
+            <p className="label">Recent events</p>
+          </div>
+          <TurnLog entries={log} />
+        </section>
+      </main>
+    </div>
+  );
+}
+
+export default App;

--- a/src/components/BossCard.tsx
+++ b/src/components/BossCard.tsx
@@ -9,19 +9,32 @@ function BossCard({ boss, tell }: Props) {
   const percent = Math.max(6, Math.round((boss.health / boss.maxHealth) * 100));
 
   return (
-    <div className="boss-card">
-      <div className="boss-meta">
-        <p className="label">Boss</p>
-        <h3>{boss.name}</h3>
-        <p className="lede">{boss.description}</p>
+    <div className="boss-card" style={{ background: `radial-gradient(120% 140% at 20% 20%, ${boss.palette.glow}, ${boss.palette.base})` }}>
+      <div className="boss-visual">
+        <div className="sigil" style={{ boxShadow: `0 0 80px ${boss.palette.glow}` }}>
+          <span>{boss.sigil}</span>
+        </div>
+        <div className="boss-meta">
+          <p className="label">{boss.title}</p>
+          <h3>{boss.name}</h3>
+          <p className="lede">{boss.description}</p>
+        </div>
       </div>
       <div className="boss-health">
         <div className="health-bar">
-          <div className="health-fill" style={{ width: `${percent}%` }} />
+          <div className="health-fill" style={{ width: `${percent}%`, background: boss.palette.accent }} />
         </div>
         <p className="hint">Quirk: {boss.quirk}</p>
-        <p className="hint">Weakness: {boss.weakness.toUpperCase()}</p>
+        <p className="hint">Elemental focus: {boss.element.toUpperCase()}</p>
         {tell && <p className="hint callout">Next: {tell}</p>}
+      </div>
+      <div className="boss-skills">
+        {boss.skills.map((skill) => (
+          <div key={skill.name} className="skill-chip">
+            <p className="label">{skill.name}</p>
+            <p className="hint">{skill.description}</p>
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/src/components/BossCard.tsx
+++ b/src/components/BossCard.tsx
@@ -2,9 +2,10 @@ import type { Boss } from '../types';
 
 interface Props {
   boss: Boss;
+  tell?: string;
 }
 
-function BossCard({ boss }: Props) {
+function BossCard({ boss, tell }: Props) {
   const percent = Math.max(6, Math.round((boss.health / boss.maxHealth) * 100));
 
   return (
@@ -20,6 +21,7 @@ function BossCard({ boss }: Props) {
         </div>
         <p className="hint">Quirk: {boss.quirk}</p>
         <p className="hint">Weakness: {boss.weakness.toUpperCase()}</p>
+        {tell && <p className="hint callout">Next: {tell}</p>}
       </div>
     </div>
   );

--- a/src/components/BossCard.tsx
+++ b/src/components/BossCard.tsx
@@ -1,0 +1,28 @@
+import type { Boss } from '../types';
+
+interface Props {
+  boss: Boss;
+}
+
+function BossCard({ boss }: Props) {
+  const percent = Math.max(6, Math.round((boss.health / boss.maxHealth) * 100));
+
+  return (
+    <div className="boss-card">
+      <div className="boss-meta">
+        <p className="label">Boss</p>
+        <h3>{boss.name}</h3>
+        <p className="lede">{boss.description}</p>
+      </div>
+      <div className="boss-health">
+        <div className="health-bar">
+          <div className="health-fill" style={{ width: `${percent}%` }} />
+        </div>
+        <p className="hint">Quirk: {boss.quirk}</p>
+        <p className="hint">Weakness: {boss.weakness.toUpperCase()}</p>
+      </div>
+    </div>
+  );
+}
+
+export default BossCard;

--- a/src/components/LetterPool.tsx
+++ b/src/components/LetterPool.tsx
@@ -1,0 +1,46 @@
+import { useMemo, useState } from 'react';
+
+interface Props {
+  letters: string[];
+  onCast: (word: string) => void;
+}
+
+function LetterPool({ letters, onCast }: Props) {
+  const [draft, setDraft] = useState('');
+
+  const isValid = useMemo(() => draft.length >= 3, [draft]);
+
+  return (
+    <div className="letter-pool">
+      <div className="letters">
+        {letters.map((letter, idx) => (
+          <span key={`${letter}-${idx}`} className="tile">
+            {letter}
+          </span>
+        ))}
+      </div>
+      <label className="label" htmlFor="draft">Spell a word</label>
+      <div className="draft">
+        <input
+          id="draft"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          placeholder="Type a word using these letters"
+        />
+        <button
+          className="primary"
+          disabled={!isValid}
+          onClick={() => {
+            onCast(draft);
+            setDraft('');
+          }}
+        >
+          Cast
+        </button>
+      </div>
+      <p className="hint">3+ letters to cast. First-time words get added to your spellbook.</p>
+    </div>
+  );
+}
+
+export default LetterPool;

--- a/src/components/LetterPool.tsx
+++ b/src/components/LetterPool.tsx
@@ -3,9 +3,11 @@ import { useMemo, useState } from 'react';
 interface Props {
   letters: string[];
   onCast: (word: string) => void;
+  onReroll: () => void;
+  disabled?: boolean;
 }
 
-function LetterPool({ letters, onCast }: Props) {
+function LetterPool({ letters, onCast, onReroll, disabled = false }: Props) {
   const [draft, setDraft] = useState('');
 
   const isValid = useMemo(() => draft.length >= 3, [draft]);
@@ -26,10 +28,11 @@ function LetterPool({ letters, onCast }: Props) {
           value={draft}
           onChange={(e) => setDraft(e.target.value)}
           placeholder="Type a word using these letters"
+          disabled={disabled}
         />
         <button
           className="primary"
-          disabled={!isValid}
+          disabled={!isValid || disabled}
           onClick={() => {
             onCast(draft);
             setDraft('');
@@ -38,7 +41,12 @@ function LetterPool({ letters, onCast }: Props) {
           Cast
         </button>
       </div>
-      <p className="hint">3+ letters to cast. First-time words get added to your spellbook.</p>
+      <div className="letter-actions">
+        <p className="hint">3+ letters to cast. First-time words get added to your spellbook.</p>
+        <button className="ghost" onClick={onReroll} disabled={disabled}>
+          Reroll letters
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/components/RunStats.tsx
+++ b/src/components/RunStats.tsx
@@ -1,0 +1,55 @@
+import type { PlayerState, Spell } from '../types';
+
+interface Props {
+  player: PlayerState;
+  mana: number;
+  turn: number;
+  discoveredSpells: Spell[];
+  bossName: string;
+}
+
+function RunStats({ player, mana, turn, discoveredSpells, bossName }: Props) {
+  const discoveryCount = Math.max(0, discoveredSpells.length - 2);
+  const manaPercent = Math.min(100, (mana / 8) * 100);
+  const healthPercent = Math.max(6, Math.round((player.health / player.maxHealth) * 100));
+
+  return (
+    <section className="panel">
+      <div className="panel-head">
+        <h2>Run State</h2>
+        <p className="label">{bossName} · Turn {turn}</p>
+      </div>
+      <div className="stat-grid">
+        <article className="stat-card">
+          <p className="label">Player Vitality</p>
+          <div className="meter chunky">
+            <div className="fill" style={{ width: `${healthPercent}%` }} />
+          </div>
+          <p className="hint">{player.health} / {player.maxHealth} HP · Shield {player.shield}</p>
+        </article>
+
+        <article className="stat-card">
+          <p className="label">Mana Flow</p>
+          <div className="meter">
+            <div className="fill" style={{ width: `${manaPercent}%` }} />
+          </div>
+          <p className="hint">{mana} MP · +1 regen each turn</p>
+        </article>
+
+        <article className="stat-card">
+          <p className="label">Combo Heat</p>
+          <h3>{player.combo}×</h3>
+          <p className="hint">Longer chains boost spell power.</p>
+        </article>
+
+        <article className="stat-card">
+          <p className="label">Discoveries</p>
+          <h3>{discoveryCount}</h3>
+          <p className="hint">Fresh spells forged this run.</p>
+        </article>
+      </div>
+    </section>
+  );
+}
+
+export default RunStats;

--- a/src/components/Spellbook.tsx
+++ b/src/components/Spellbook.tsx
@@ -3,9 +3,11 @@ import type { Spell } from '../types';
 interface Props {
   spells: Spell[];
   onRecast: (spell: Spell) => void;
+  disabled?: boolean;
+  manaAvailable?: number;
 }
 
-function Spellbook({ spells, onRecast }: Props) {
+function Spellbook({ spells, onRecast, disabled = false, manaAvailable = 0 }: Props) {
   return (
     <div className="spellbook">
       {spells.map((spell) => (
@@ -17,7 +19,11 @@ function Spellbook({ spells, onRecast }: Props) {
           </div>
           <div className="spell-actions">
             <p className="mana">{spell.manaCost} MP</p>
-            <button className="ghost" onClick={() => onRecast(spell)}>
+            <button
+              className="ghost"
+              onClick={() => onRecast(spell)}
+              disabled={disabled || manaAvailable < spell.manaCost}
+            >
               Recast
             </button>
           </div>

--- a/src/components/Spellbook.tsx
+++ b/src/components/Spellbook.tsx
@@ -1,0 +1,30 @@
+import type { Spell } from '../types';
+
+interface Props {
+  spells: Spell[];
+  onRecast: (spell: Spell) => void;
+}
+
+function Spellbook({ spells, onRecast }: Props) {
+  return (
+    <div className="spellbook">
+      {spells.map((spell) => (
+        <article key={spell.name} className="spell">
+          <div>
+            <p className="label">{spell.element.toUpperCase()}</p>
+            <h3>{spell.name}</h3>
+            <p className="hint">{spell.description}</p>
+          </div>
+          <div className="spell-actions">
+            <p className="mana">{spell.manaCost} MP</p>
+            <button className="ghost" onClick={() => onRecast(spell)}>
+              Recast
+            </button>
+          </div>
+        </article>
+      ))}
+    </div>
+  );
+}
+
+export default Spellbook;

--- a/src/components/TurnLog.tsx
+++ b/src/components/TurnLog.tsx
@@ -1,0 +1,15 @@
+interface Props {
+  entries: string[];
+}
+
+function TurnLog({ entries }: Props) {
+  return (
+    <ol className="turn-log">
+      {entries.map((entry, index) => (
+        <li key={`${entry}-${index}`}>{entry}</li>
+      ))}
+    </ol>
+  );
+}
+
+export default TurnLog;

--- a/src/logic/core.ts
+++ b/src/logic/core.ts
@@ -1,43 +1,110 @@
-import type { Boss, Element, WordResolution, WordTrait } from '../types';
+import type { Boss, BossSkill, Element, WordResolution, WordTrait } from '../types';
 
-const bosses: Boss[] = [
+const archetypes: Array<
+  Omit<Boss, 'name' | 'title' | 'health' | 'maxHealth' | 'skills'> & {
+    baseHealth: number;
+    signatureSkills: BossSkill[];
+  }
+> = [
   {
-    name: 'The Leximancer',
+    title: 'The Leximancer',
     description: 'A flaming tome that consumes vowels every third turn.',
-    health: 220,
-    maxHealth: 220,
     quirk: 'Removes vowels; vulnerable to long words.',
-    weakness: 'fire'
+    weakness: 'fire',
+    element: 'fire',
+    sigil: '📕',
+    palette: { base: '#120808', glow: '#ff4d2e', accent: '#ffb347' },
+    letterBias: 'FLARE',
+    baseHealth: 220,
+    signatureSkills: [
+      { name: 'Vowel Burn', description: 'Consumes vowels from your pool.', tell: 'Pages ignite; vowels smolder.' },
+      { name: 'Incinerate', description: 'Heavy hit if you played short words.', tell: 'Spits embers at close range.' }
+    ]
   },
   {
-    name: 'Queen Anagramma',
+    title: 'Queen Anagramma',
     description: 'She scrambles learned spells, forcing improvisation.',
-    health: 180,
-    maxHealth: 180,
     quirk: 'Scrambles spell names each round.',
-    weakness: 'arcane'
+    weakness: 'arcane',
+    element: 'arcane',
+    sigil: '🕸️',
+    palette: { base: '#0c0a17', glow: '#6f62ff', accent: '#c0b7ff' },
+    letterBias: 'AEIOQNRST',
+    baseHealth: 200,
+    signatureSkills: [
+      { name: 'Scramble', description: 'Shuffles discovered spells.', tell: 'Threads weave; your book rattles.' },
+      { name: 'Mirror Bite', description: 'Copies your last element.', tell: 'Reflective glyphs shimmer.' }
+    ]
   },
   {
-    name: 'The Silent Editor',
+    title: 'The Silent Editor',
     description: 'Rejects typos and punishes sloppy spelling.',
-    health: 200,
-    maxHealth: 200,
     quirk: 'Invalid words trigger backlash.',
-    weakness: 'void'
+    weakness: 'void',
+    element: 'void',
+    sigil: '✒️',
+    palette: { base: '#050608', glow: '#0cf2c9', accent: '#7fffe0' },
+    letterBias: 'EDTIRN',
+    baseHealth: 210,
+    signatureSkills: [
+      { name: 'Red Pen', description: 'Backlash on invalid words.', tell: 'Ink drips—don’t misspell.' },
+      { name: 'Silence', description: 'Weakens repeated spells.', tell: 'The air hushes ominously.' }
+    ]
   }
 ];
 
+const bossAdjectives = ['Elder', 'Glitched', 'Astral', 'Volatile', 'Primordial', 'Gilded', 'Runic'];
+const bossSuffixes = ['of the Stack', 'of Ruin', 'of Echoes', 'of Cinders', 'of Frost', 'of Static'];
+
+function sample<T>(items: T[]): T {
+  return items[Math.floor(Math.random() * items.length)];
+}
+
+function rollSkills(signatureSkills: BossSkill[]): BossSkill[] {
+  const remix: BossSkill[] = [...signatureSkills];
+  const extra: BossSkill[] = [
+    { name: 'Phase Shift', description: 'Gains shield every third turn.', tell: 'Reality blurs around the boss.' },
+    { name: 'Echo Pulse', description: 'Repeats the previous attack at half damage.', tell: 'A second wave builds.' },
+    { name: 'Mana Siphon', description: 'Reduces your mana if you play short words.', tell: 'Runes drain the arena.' }
+  ];
+  remix.push(sample(extra));
+  return remix;
+}
+
 export function pickBoss(): Boss {
-  return bosses[Math.floor(Math.random() * bosses.length)];
+  const archetype = sample(archetypes);
+  const adjective = sample(bossAdjectives);
+  const suffix = sample(bossSuffixes);
+  const variantHealth = archetype.baseHealth + Math.round(Math.random() * 35);
+  const name = `${adjective} ${archetype.title}`;
+
+  return {
+    ...archetype,
+    name,
+    title: suffix,
+    description: `${archetype.description} This variant is ${adjective.toLowerCase()} and ${suffix.toLowerCase()}.`,
+    health: variantHealth,
+    maxHealth: variantHealth,
+    skills: rollSkills(archetype.signatureSkills)
+  };
 }
 
 const letterBag = 'AABCDEEEFGHIIIJKLMNOOPQRSTUUVXYZ';
+const elementBias: Record<Element, string> = {
+  fire: 'FIR',
+  ice: 'ICE',
+  void: 'VOD',
+  arcane: 'ARC',
+  storm: 'STO'
+};
 
-export function generateLetters(count: number): string[] {
+export function generateLetters(count: number, focus?: Element, biasLetters?: string): string[] {
   const output: string[] = [];
+  const biasPool = `${biasLetters ?? ''}${focus ? elementBias[focus] : ''}`;
+  const pool = `${letterBag}${biasPool}`;
   for (let i = 0; i < count; i += 1) {
-    const index = Math.floor(Math.random() * letterBag.length);
-    output.push(letterBag[index]);
+    const index = Math.floor(Math.random() * pool.length);
+    output.push(pool[index]);
   }
   return output;
 }

--- a/src/logic/core.ts
+++ b/src/logic/core.ts
@@ -1,4 +1,4 @@
-import type { Boss } from '../types';
+import type { Boss, Element, WordResolution, WordTrait } from '../types';
 
 const bosses: Boss[] = [
   {
@@ -40,4 +40,51 @@ export function generateLetters(count: number): string[] {
     output.push(letterBag[index]);
   }
   return output;
+}
+
+function detectElement(word: string): Element {
+  const upper = word.toUpperCase();
+  if (upper.includes('ICE')) return 'ice';
+  if (upper.includes('FIRE') || upper.includes('FLAME')) return 'fire';
+  if (upper.includes('VOID') || upper.includes('HEX')) return 'void';
+  if (upper.includes('STORM') || upper.includes('SHOCK')) return 'storm';
+  return 'arcane';
+}
+
+const rareLetters = new Set(['Q', 'Z', 'X', 'J']);
+
+export function resolveWord(word: string, weakness: Element, combo: number): WordResolution {
+  const upper = word.toUpperCase();
+  const element = detectElement(upper);
+  const traits: WordTrait[] = [];
+
+  const lengthBonus = upper.length >= 7 ? 10 : 0;
+  if (lengthBonus) traits.push('lengthy');
+
+  let rareBonus = 0;
+  for (const char of upper) {
+    if (rareLetters.has(char)) {
+      rareBonus += 8;
+      if (!traits.includes('rare-letter')) traits.push('rare-letter');
+    }
+  }
+
+  const uniqueLetters = new Set(upper);
+  const repeatBonus = upper.length - uniqueLetters.size > 1 ? 6 : 0;
+  if (repeatBonus) traits.push('repeater');
+
+  const isPalindrome = upper === upper.split('').reverse().join('');
+  if (isPalindrome) traits.push('palindrome');
+
+  const weaknessMultiplier = element === weakness ? 1.2 : 1;
+  if (weaknessMultiplier > 1) traits.push('weakness-hit');
+
+  const baseDamage = upper.length * 6;
+  const comboBonus = combo * 3;
+  const damage = Math.round((baseDamage + lengthBonus + rareBonus + repeatBonus + comboBonus) * weaknessMultiplier);
+
+  const manaBonus = traits.includes('lengthy') ? 1 : 0;
+  const shieldBonus = isPalindrome ? 6 : 0;
+
+  return { damage, element, traits, manaBonus, shieldBonus };
 }

--- a/src/logic/core.ts
+++ b/src/logic/core.ts
@@ -1,0 +1,43 @@
+import type { Boss } from '../types';
+
+const bosses: Boss[] = [
+  {
+    name: 'The Leximancer',
+    description: 'A flaming tome that consumes vowels every third turn.',
+    health: 220,
+    maxHealth: 220,
+    quirk: 'Removes vowels; vulnerable to long words.',
+    weakness: 'fire'
+  },
+  {
+    name: 'Queen Anagramma',
+    description: 'She scrambles learned spells, forcing improvisation.',
+    health: 180,
+    maxHealth: 180,
+    quirk: 'Scrambles spell names each round.',
+    weakness: 'arcane'
+  },
+  {
+    name: 'The Silent Editor',
+    description: 'Rejects typos and punishes sloppy spelling.',
+    health: 200,
+    maxHealth: 200,
+    quirk: 'Invalid words trigger backlash.',
+    weakness: 'void'
+  }
+];
+
+export function pickBoss(): Boss {
+  return bosses[Math.floor(Math.random() * bosses.length)];
+}
+
+const letterBag = 'AABCDEEEFGHIIIJKLMNOOPQRSTUUVXYZ';
+
+export function generateLetters(count: number): string[] {
+  const output: string[] = [];
+  for (let i = 0; i < count; i += 1) {
+    const index = Math.floor(Math.random() * letterBag.length);
+    output.push(letterBag[index]);
+  }
+  return output;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './style.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/style.css
+++ b/src/style.css
@@ -1,0 +1,280 @@
+:root {
+  color-scheme: light;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: radial-gradient(circle at 20% 20%, #1c1f30, #0b0d15 60%);
+  color: #f5f7fb;
+  --panel: rgba(255, 255, 255, 0.04);
+  --border: rgba(255, 255, 255, 0.08);
+  --accent: #89f0ff;
+  --accent-strong: #3bd0ff;
+  --muted: #9aa3b5;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at 20% 20%, #1c1f30, #0b0d15 60%);
+  color: #f5f7fb;
+  min-height: 100vh;
+}
+
+button {
+  font: inherit;
+  cursor: pointer;
+}
+
+.page {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 48px 24px 64px;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 24px;
+  align-items: center;
+  margin-bottom: 32px;
+}
+
+.hero h1 {
+  margin: 4px 0 12px;
+  font-size: 34px;
+  letter-spacing: -0.02em;
+}
+
+.hero .lede {
+  color: var(--muted);
+  margin: 0 0 16px;
+  line-height: 1.5;
+}
+
+.hero-actions {
+  display: flex;
+  gap: 12px;
+}
+
+.stat-card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  padding: 18px;
+  border-radius: 16px;
+}
+
+.stat-card .meter {
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 12px;
+  height: 10px;
+  overflow: hidden;
+  margin: 8px 0 12px;
+}
+
+.stat-card .fill {
+  background: linear-gradient(90deg, #5df1c1, var(--accent-strong));
+  height: 100%;
+  transition: width 0.25s ease;
+}
+
+.value {
+  font-size: 28px;
+  margin: 4px 0 0;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 16px;
+}
+
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  padding: 20px;
+  border-radius: 16px;
+  backdrop-filter: blur(8px);
+}
+
+.panel-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.eyebrow {
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  font-size: 12px;
+  color: var(--muted);
+  margin: 0;
+}
+
+.label {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 11px;
+  color: var(--muted);
+  margin: 0 0 6px;
+}
+
+.hint {
+  color: var(--muted);
+  margin: 4px 0;
+}
+
+.lede {
+  color: var(--muted);
+  margin-top: 0;
+}
+
+.primary,
+.ghost {
+  border-radius: 12px;
+  border: 1px solid transparent;
+  padding: 10px 14px;
+  font-weight: 700;
+  transition: transform 0.15s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease;
+  color: #0b0d15;
+}
+
+.primary {
+  background: linear-gradient(135deg, #89f0ff, #a3ff9b);
+  border-color: rgba(255, 255, 255, 0.06);
+}
+
+.primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(137, 240, 255, 0.25);
+}
+
+.primary:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.ghost {
+  background: transparent;
+  color: #f5f7fb;
+  border-color: var(--border);
+}
+
+.ghost:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.boss-card {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 12px;
+  align-items: center;
+  padding: 12px;
+  border-radius: 12px;
+  background: linear-gradient(135deg, rgba(137, 240, 255, 0.1), rgba(255, 255, 255, 0.02));
+  border: 1px solid var(--border);
+}
+
+.boss-health .health-bar {
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+  height: 12px;
+  overflow: hidden;
+  margin: 8px 0;
+}
+
+.health-fill {
+  background: linear-gradient(90deg, #ff7b7b, #ff4545);
+  height: 100%;
+  transition: width 0.25s ease;
+}
+
+.letter-pool .letters {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(40px, 1fr));
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.tile {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px 0;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid var(--border);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
+.draft {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.draft input {
+  flex: 1;
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.04);
+  color: #f5f7fb;
+  font-size: 15px;
+}
+
+.spellbook {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.spell {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 12px;
+  padding: 12px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.spell-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
+}
+
+.mana {
+  margin: 0;
+  font-weight: 700;
+}
+
+.turn-log {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.turn-log li {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 10px 12px;
+}
+
+@media (max-width: 860px) {
+  .hero {
+    grid-template-columns: 1fr;
+  }
+
+  .boss-card {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/style.css
+++ b/src/style.css
@@ -196,12 +196,44 @@ button {
 .boss-card {
   display: grid;
   grid-template-columns: 2fr 1fr;
+  grid-template-areas:
+    'visual health'
+    'skills skills';
   gap: 12px;
   align-items: center;
-  padding: 12px;
-  border-radius: 12px;
-  background: linear-gradient(135deg, rgba(137, 240, 255, 0.1), rgba(255, 255, 255, 0.02));
+  padding: 16px;
+  border-radius: 14px;
   border: 1px solid var(--border);
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.boss-visual {
+  grid-area: visual;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.sigil {
+  width: 74px;
+  height: 74px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  display: grid;
+  place-items: center;
+  font-size: 32px;
+  transition: transform 0.2s ease;
+}
+
+.boss-card:hover .sigil {
+  transform: translateY(-2px) scale(1.03);
+}
+
+.boss-health {
+  grid-area: health;
 }
 
 .boss-health .health-bar {
@@ -216,6 +248,21 @@ button {
   background: linear-gradient(90deg, #ff7b7b, #ff4545);
   height: 100%;
   transition: width 0.25s ease;
+}
+
+.boss-skills {
+  grid-area: skills;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 10px;
+}
+
+.skill-chip {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 10px 12px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
 }
 
 .letter-pool .letters {
@@ -312,5 +359,9 @@ button {
 
   .boss-card {
     grid-template-columns: 1fr;
+    grid-template-areas:
+      'visual'
+      'health'
+      'skills';
   }
 }

--- a/src/style.css
+++ b/src/style.css
@@ -83,6 +83,20 @@ button {
   margin: 4px 0 0;
 }
 
+.stat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+}
+
+.stat-card h3 {
+  margin: 4px 0;
+}
+
+.meter.chunky {
+  height: 16px;
+}
+
 .grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
@@ -125,6 +139,15 @@ button {
   margin: 4px 0;
 }
 
+.hint.callout {
+  display: inline-block;
+  background: rgba(137, 240, 255, 0.08);
+  color: #f5f7fb;
+  padding: 6px 10px;
+  border-radius: 10px;
+  margin-top: 6px;
+}
+
 .lede {
   color: var(--muted);
   margin-top: 0;
@@ -163,6 +186,11 @@ button {
 
 .ghost:hover {
   background: rgba(255, 255, 255, 0.04);
+}
+
+.ghost:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
 }
 
 .boss-card {
@@ -223,6 +251,14 @@ button {
   background: rgba(255, 255, 255, 0.04);
   color: #f5f7fb;
   font-size: 15px;
+}
+
+.letter-actions {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  margin-top: 8px;
 }
 
 .spellbook {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,17 @@
+export type Element = 'fire' | 'ice' | 'void' | 'arcane' | 'storm';
+
+export interface Boss {
+  name: string;
+  description: string;
+  health: number;
+  maxHealth: number;
+  quirk: string;
+  weakness: Element;
+}
+
+export interface Spell {
+  name: string;
+  description: string;
+  manaCost: number;
+  element: Element;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,13 +7,29 @@ export type WordTrait =
   | 'palindrome'
   | 'weakness-hit';
 
+export interface BossSkill {
+  name: string;
+  description: string;
+  tell: string;
+}
+
 export interface Boss {
   name: string;
+  title: string;
   description: string;
   health: number;
   maxHealth: number;
   quirk: string;
   weakness: Element;
+  element: Element;
+  sigil: string;
+  palette: {
+    base: string;
+    glow: string;
+    accent: string;
+  };
+  skills: BossSkill[];
+  letterBias?: string;
 }
 
 export interface PlayerState {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,12 @@
 export type Element = 'fire' | 'ice' | 'void' | 'arcane' | 'storm';
 
+export type WordTrait =
+  | 'lengthy'
+  | 'rare-letter'
+  | 'repeater'
+  | 'palindrome'
+  | 'weakness-hit';
+
 export interface Boss {
   name: string;
   description: string;
@@ -9,9 +16,24 @@ export interface Boss {
   weakness: Element;
 }
 
+export interface PlayerState {
+  health: number;
+  maxHealth: number;
+  shield: number;
+  combo: number;
+}
+
 export interface Spell {
   name: string;
   description: string;
   manaCost: number;
   element: Element;
+}
+
+export interface WordResolution {
+  damage: number;
+  element: Element;
+  traits: WordTrait[];
+  manaBonus: number;
+  shieldBonus: number;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Node",
+    "allowImportingTsExtensions": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "types": ["node"]
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    host: true
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold a React + Vite + Capacitor project for the Word Wizards boss-rush prototype
- implement a vertical-slice UI with boss arena, letter pool, spellbook, and event log interactions
- add styling, configuration, and documentation to prepare for mobile builds

## Testing
- not run (npm registry access blocked in environment)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e56695ee8832faf90651108e94c8d)